### PR TITLE
Add switch for altering tac by obs data

### DIFF
--- a/CODE_TO_ALTER_Spatial_BRP.dat
+++ b/CODE_TO_ALTER_Spatial_BRP.dat
@@ -3,11 +3,14 @@
 15
 #nyrs
 200
-#nstocks
+#npopulations
 1
 #nregions
 2
 #nfleets
+1
+1
+#nfleets_survey
 1
 1
 #model_type_switch
@@ -15,6 +18,17 @@
   #==1 use TAC to set F
   #==2 use uMSY to set F
 0
+# parse_TAC
+  #==0 do not alter the input TAC or harvest rate
+  #==1 use observed data source to parse TAC or harvest rate (used when allocating harvest but pop structure unknown)
+1
+#parse_TAC_source
+  #==0 recruitment index_BM
+  #==1 recruitment index_AM
+  #==2 survey numbers
+  #==3 survey biomass
+  #==4 historical catch (NEEDS WORK)
+0  
 #larval_move_switch
   #==0 no movement
   #==1 input movement
@@ -32,11 +46,14 @@
   #==5 allow movement across all regions and stocks, based on stock/region specific residency (symmetric off diagnol)
   #==6 natal return, based on age of return and return probability (certain fraction of fish make return migration to natal stock eg ontogenetic migration)
 1
-#overlap switch
-  #==0 no overlap (SSB is sum of SSB in stock regardless of natal origin; weight/mat/fecund/ are based on current stock not natal stock)
-  #==1 do overlap (a fish only adds to SSB if it is in its natal stock at spawning time; weight/mat/fecund/ are based on natal stock)
-  #==2 do overlap with natal migration (a fraction of fish return to natal stock to spawn (instantaneous migration to natal population and back at time of spawning) based spawn_return_prob; weight/mat/fecund/ are based on natal stock)
-  #overlap>0 assumes genetic based life history and contribution to SSB (i.e., natal homing and no demographic mixing), overlap==0 assumes demographic mixing (e.g. metapopulations where life history is more location based)
+#natal homing switch
+  #==0 no natal homing (SSB is sum of SSB in population regardless of natal origin; weight/mat/fecund/ are based on current population not natal population) - Metapopulation/metamictic
+  #==1 do natal homing (a fish only adds to SSB if it is in its natal population at spawning time; weight/mat/fecund/ are based on natal population) - Natal homing
+  #natal homing  assumes genetic based life history and contribution to SSB (i.e., natal homing and no demographic mixing), natal homing==0 assumes demographic mixing (e.g. metapopulations where life history is more location based)
+0
+#spawn_return_switch
+   #==0 if natal_homing_switch==1 then only fish that are in natal population add to SSB
+   #==1 natal_homing_switch==1 a fraction of fish return to natal population to spawn (inpsantaneous migration to natal population and back at time of spawning) based spawn_return_prob; weight/mat/fecund/ are based on natal population)
 0
 #select_switch
   #==0 input selectivity
@@ -57,8 +74,12 @@
   #==1 allow lognormal error around SR curve (i.e., include randomness based on input sigma_recruit)
 0
 #maturity_switch_equil
-  #==0 if maturity is equal across areas or straight average if unequal
-  #==1 weighted average of maturity if unequal across areas. Weighted by equilibrium ssb apportionment(equil_ssb_appor).
+  #//==0 for equal by area or average
+  #//==1 weighted average using equil_ssb_apportion to determine proportional contribution to equil vital rates by region
+  #//SSB0 must be calculated to determine stock-recruit function (if only know steepness and R0 for the population)
+  #//Use equilibrium SPR calcs to get SSB0, but to do so requires vital rates (maturity, weight), which are typically constant across a population
+  #//With multiple regions within a pop each with different vitals, must make assumption regarding the proportional contribution of each region's demograhics to equil SSB
+  #//When ==1 just assume equal (average) contributions, when ==1 input a proportional contribution (ie assume one region has higher carrying capacity and contributes more to equil SSB)
 1
 #SSB_type
   #==1 fecundity based SSB
@@ -72,7 +93,7 @@
   #==3 recruits are apportioned in a completely random manner with uniform equilibrium distribution
   #==4 recruits are apportioned stochastically with error surrounding the input proportions
   #==5 recruits are approtioned based on theoretical enviormental phase shift.. working on
-4
+1
 #Rec_type
   #==1 stock-recruit relationship assumes an average value based on R_ave
   #==2 Beverton-Holt stock-recruit functions based on stock-specific input steepness, R0 (R_ave), M, and weight

--- a/CODE_TO_ALTER_Spatial_BRP.tpl
+++ b/CODE_TO_ALTER_Spatial_BRP.tpl
@@ -1114,11 +1114,7 @@ FUNCTION get_abundance
                    true_survey_index_fleet(j,r,y,a,z)=survey_selectivity(j,r,y,a,z)*abundance_at_age_AM(j,r,y,a)*q_survey(j,r,z);
                    true_survey_index_region_age(j,r,y,a)=sum(true_survey_index_fleet(j,r,y,a));
                    true_survey_index_region(j,r,y)=sum(true_survey_index_region_age(j,r,y));
-                  for (int m=1;m<=nages;m++)
-                    {
-                     true_survey_index_region_prop(j,y,r,m)=true_survey_index_region_age(j,r,y,m)/true_survey_index_region(j,r,y);
-                    }
-
+                   true_survey_index_region_prop(j,r,y,a)=true_survey_index_region_age(j,r,y,a)/true_survey_index_region(j,r,y);
                 true_survey_index_pop_temp(j,y,r)=true_survey_index_region(j,r,y);
                 true_survey_index_population(j,y)=sum(true_survey_index_pop_temp(j,y));
 
@@ -1131,18 +1127,13 @@ FUNCTION get_abundance
 
                 //apply the process error of aging...probably overkill
                 OBS_index_region_age(j,r,y,a)=true_survey_index_region_age(j,r,y,a)*mfexp(randn(myrand)*caa_sigma_survey(a)-0.5*square(caa_sigma_survey(a)));
-                   for (int m=1;m<=nages;m++)
-                    {
-                    OBS_index_region_prop(j,r,y,m)=OBS_index_region_age(j,r,y,m)/sum(OBS_index_region_age(j,r,y));   
-                    }
+
+                 OBS_index_region_prop(j,r,y,a)=OBS_index_region_age(j,r,y,a)/sum(OBS_index_region_age(j,r,y));   
 
                 OBS_survey_biomass_age(j,r,y,a)= OBS_index_region_age(j,r,y,a)*weight_population(j,y,a);
                 OBS_survey_biomass_region(j,r,y)=sum(OBS_survey_biomass_age(j,r,y));
                 OBS_survey_biomass_pop_temp(j,y,r)=OBS_survey_biomass_region(j,r,y);
-               
-                
-                
-                 //apportion variables
+             //apportion variables
                 apport_region_survey(j,r,y)=OBS_index_region(j,r,y)/OBS_index_population(j,y);
                 apport_region_survey_biomass(j,r,y)= OBS_survey_biomass_region(j,r,y)/sum(OBS_survey_biomass_pop_temp(j,y));
                    
@@ -1689,10 +1680,8 @@ FUNCTION get_abundance
                  {
                    abundance_at_age_BM_overlap_region(p,j,y,a,r)=0;
                  }
-
-
+                 
                 abundance_at_age_BM_overlap_population(p,j,y,a)=sum(abundance_at_age_BM_overlap_region(p,j,y,a));
-
                 abundance_move_overlap_temp=0;
 
                 for (int k=1;k<=npops;k++)
@@ -1879,10 +1868,10 @@ FUNCTION get_abundance
 
                    }
 
-                recruits_AM(j,r,y)=abundance_at_age_AM(j,r,y,a);
-                rec_index_AM(j,r,y)=recruits_AM(j,r,y)*mfexp(randn(myrand)*rec_index_sigma(j,r)-0.5*square(rec_index_sigma(j,r)));
-                rec_index_AM_temp(j,y,r)=rec_index_AM(j,r,y);
-                rec_index_prop_AM(j,r,y)=rec_index_AM(j,r,y)/sum(rec_index_AM_temp(j,y));
+               recruits_AM(j,r,y)=abundance_at_age_AM(j,r,y,a);
+               rec_index_AM(j,r,y)=recruits_AM(j,r,y)*mfexp(randn(myrand)*rec_index_sigma(j,r)-0.5*square(rec_index_sigma(j,r)));
+               rec_index_AM_temp(j,y,r)=rec_index_AM(j,r,y);
+               rec_index_prop_AM(j,r,y)=rec_index_AM(j,r,y)/sum(rec_index_AM_temp(j,y));
 
                 biomass_population_temp(j,y,r)=biomass_AM(j,r,y);
                 biomass_population(j,y)=sum(biomass_population_temp(j,y));
@@ -2260,11 +2249,7 @@ FUNCTION get_abundance
                    true_survey_index_fleet(j,r,y,a,z)=survey_selectivity(j,r,y,a,z)*abundance_at_age_AM(j,r,y,a)*q_survey(j,r,z);
                    true_survey_index_region_age(j,r,y,a)=sum(true_survey_index_fleet(j,r,y,a));
                    true_survey_index_region(j,r,y)=sum(true_survey_index_region_age(j,r,y));
-                  for (int m=1;m<=nages;m++)
-                    {
-                     true_survey_index_region_prop(j,y,r,m)=true_survey_index_region_age(j,r,y,m)/true_survey_index_region(j,r,y);
-                    }
-
+                   true_survey_index_region_prop(j,r,y,a)=true_survey_index_region_age(j,r,y,a)/true_survey_index_region(j,r,y);
                 true_survey_index_pop_temp(j,y,r)=true_survey_index_region(j,r,y);
                 true_survey_index_population(j,y)=sum(true_survey_index_pop_temp(j,y));
 
@@ -2277,14 +2262,12 @@ FUNCTION get_abundance
 
                 //apply the process error of aging...probably overkill
                 OBS_index_region_age(j,r,y,a)=true_survey_index_region_age(j,r,y,a)*mfexp(randn(myrand)*caa_sigma_survey(a)-0.5*square(caa_sigma_survey(a)));
-                   for (int m=1;m<=nages;m++)
-                    {
-                    OBS_index_region_prop(j,r,y,m)=OBS_index_region_age(j,r,y,m)/sum(OBS_index_region_age(j,r,y));   
-                    }
 
-                OBS_survey_biomass_age(j,r,y,a)= OBS_index_region_age(j,r,y,a)*weight_population(j,y,a);
-                OBS_survey_biomass_region(j,r,y)=sum(OBS_survey_biomass_age(j,r,y));
-                OBS_survey_biomass_pop_temp(j,y,r)=OBS_survey_biomass_region(j,r,y);
+                   OBS_index_region_prop(j,r,y,a)=OBS_index_region_age(j,r,y,a)/sum(OBS_index_region_age(j,r,y));   
+
+               OBS_survey_biomass_age(j,r,y,a)= OBS_index_region_age(j,r,y,a)*weight_population(j,y,a);
+               OBS_survey_biomass_region(j,r,y)=sum(OBS_survey_biomass_age(j,r,y));
+               OBS_survey_biomass_pop_temp(j,y,r)=OBS_survey_biomass_region(j,r,y);
                
                 
                 


### PR DESCRIPTION
Added ability to apportion input TAC or harvest rate based on observed survey or recruitment index.  Added a series of associated switches to NR calcs.  

Added ability to calc a recruit index before or after movement.

Fixed typo in survey calcs that caused model to crash.

Renamed overlap_switch to natal_homing_switch and separated it into two switches with a new spawn_return_switch.

Handful of minor aesthetic changes, updated commentary, etc...