### PR TITLE
added error to regional SSB indices

### DIFF
--- a/Spatial_BRP_project/Operating_Model/CODE_TO_ALTER_Spatial_BRP.dat
+++ b/Spatial_BRP_project/Operating_Model/CODE_TO_ALTER_Spatial_BRP.dat
@@ -303,6 +303,9 @@
 #sigma_survey_overlap
 0.2
 0.2
+#sigma_SSB_region_error
+0.2
+0.2
 #sigma_catch
 0.05
 0.05
@@ -354,6 +357,8 @@
 0.001
 #debug
 1541
+#myseed_SSB
+71203
 #myseed_yield
 1
 #myseed_survey


### PR DESCRIPTION
2 files were changed to add in error for regional SSB indices  (CODE_TO_ALTER_Spatial_BRP.dat and CODE_TO_ALTER_Spatial_BRP.tpl) for spatial BRP operating model