### PR TITLE
Added simulated tagging data

### DIFF
--- a/Tag_Integrated_Model/Operating_Model/CODE_TO_ALTER_Spatial_BRP.dat
+++ b/Tag_Integrated_Model/Operating_Model/CODE_TO_ALTER_Spatial_BRP.dat
@@ -2,20 +2,27 @@
 #nages
 15
 #nyrs
-50
+200
 #npopulations
-1
+2
 #nregions
+2
 2
 #nfleets
 1
+1
 #nfleets_survey
+1
 1
 #model_type_switch
   #==0 do not use TAC to set F
   #==1 use TAC to set F, USE THIS IF calc_TAC_from_uMSY==1
   #==2 use uMSY to set F
 0
+#do_tag
+  #==0 do not calculate tagging data
+  #==1 calculate tagging data
+1
 # parse_TAC
   #==0 do not alter the input TAC or harvest rate
   #==1 use observed data source to parse TAC or harvest rate (used when allocating harvest but pop structure unknown)
@@ -55,8 +62,8 @@
 1
 
 #tsurvey in proportion of year (0-1)
-0
-0
+0 0
+0 0
 
 #larval_move_switch
   #==0 no movement
@@ -78,7 +85,7 @@
   #//    homing would return to natal population because natal residency is 100% and use natal movement rates (not current population movement rates like with metapopulation/random movement))
   #==8 density dependent movement based on relative biomass among potential destination area/regions, partitions (1-input_residency) based on a logistic function of biomass in current area/region and 'suitability' of destination area/regions
   #//uses use_input_Bstar switch 
-1
+0
 #use_input_Bstar
   #==0 set Bstar for DD movement equal to SSB_zero*SSB_zero_appor (if nreg==1, Bstar=SSB0), **NOTE** for Rec_type!=2 (not BH), defaults to using input_Bstar since no SSB0 calcs are done
   #==1 use input_Bstar
@@ -142,37 +149,76 @@
   #==2 Beverton-Holt stock-recruit functions based on stock-specific input steepness, R0 (R_ave), M, and weight
   #==3 cyclical (sine wave type)
 2
-#init_number use_stock_comp_info_survey
+#use_stock_comp_info_survey
  #Determines whether it is assumed that info (stock composition data) is available determine natal origin for age composition data
  #==0 calc OBS survey age comps by area (summed across natal population)
  #==1 calc OBS survey age comps by natal population within each area
 0
-#init_number use_stock_comp_info_catch
+#use_stock_comp_info_catch
  #Determines whether it is assumed that info (stock composition data) is available determine natal origin for age composition data
  #==0 calc OBS catch age comps by area (summed across natal population)
  #==1 calc OBS catch age comps by natal population within each area
 0
 
+#/////tagging data parameters
+#nyrs_release
+  #number of years with tag release events
+5
+#yrs_releases
+  #vector containing the model years with releases
+175
+180
+185
+190
+195
+#frac_total_abund_tagged
+  #proportion of total abundance that is tagged in each release year
+.01
+.01
+.01
+.01
+.01
+#max_life_tags
+  #number of years that tag recaptures will be tallied for after release (assume proportional to longevity of the species)...use this to avoid calculating tag recaptures for all remaining model years after release since # recaptures are often extremely limited after a few years after release
+5
+#SIM_ntag
+  #the ESS used to simulate multinomial tagging dat
+100
+#report_rate(1,ny_rel,1,np,1,nreg)
+  #tag reporting rate (assume constant for all recaptures within a given release cohort, but can be variable across populations or regions)...could switch to allow variation across fleets instead
+1 1
+1 1
+1 1
+1 1
+1 1
+1 1
+1 1
+1 1
+1 1
+1 1
+#//////Density-Dependent Movement parameters
 #input_Bstar(1,np,1,nreg)
   #used with move_switch==8
   #carrying capacity biomass term
-10000000
-10000000
+10000000 10000000
+10000000 10000000
 #SSB_zero_appor(1,np,1,nreg)
   #used with move_switch==8
   #determines apportionment of SSB0 when multiple regions and use_input_Bstar==0
-0.5
-0.5
+0.5 0.5
+0.5 0.5
 #A
   #used with move_switch==8
   #logistic parameter
-9
-9
+9 9
+9 9
 #return_age - age of return migration for move_switch==6
 4
 #return_probability- probability of returning for move_switch==6
 1
+1
 #spawn_return_prob - probability of returning for spawning if overlap_switch==2
+1
 1
 #phase_F - must be turned on (==1) if F_type==3
 -1
@@ -180,74 +226,191 @@
 1
 #tspawn in proportion of year (0-1)
 0
+0
 #steep
+0.814
 0.814
 #R_ave
 3125000
+3125000
 #amplitude - amplitude of occilations for recritment variation. Use when Rec_type ==3
+0.2
 0.2
 #freq - period of ossilation for recruitment variation. Use when Rec_type ==3
 15
+15
 #input_T  (1,ns,1,nreg,1,na,1,ns,1,nreg)
-0.95	0.05
-0.95	0.05
-0.8	0.2
-0.8	0.2
-0.5	0.5
-0.2	0.8
-0.2	0.8
-0.1	0.9
-0.1	0.9
-0.1	0.9
-0.1	0.9
-0.1	0.9
-0.1	0.9
-0.1	0.9
-0.1	0.9
-0.05	0.95
-0.05	0.95
-0.05	0.95
-0.05	0.95
-0.05	0.95
-0.05	0.95
-0.05	0.95
-0.05	0.95
-0.05	0.95
-0.05	0.95
-0.05	0.95
-0.05	0.95
-0.05	0.95
-0.05	0.95
-0.05	0.95
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+1 0
+
 #input_residency_larval
-1
-1
+1 1
+1 1
 #input_residency
 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75    
+0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75    
+0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5
 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5
 #sel_beta1
 0.8
+0.8
+0.8 
 0.8 
 #sel_beta2
+4
+4
 4
 4 
 #sel_beta3
 -0.6
--0.6 
+-0.6
+-0.6
+-0.6
 #sel_beta4
 20
-20   
+20
+20
+20 
 #input_selectivity (1,ns,1,nreg,1,na,1,nf)
+0	0.12	0.54	0.66	0.81	1	1	1	1	1	1	1	1	1	1
+0	0.12	0.54	0.66	0.81	1	1	1	1	1	1	1	1	1	1
 0	0.12	0.54	0.66	0.81	1	1	1	1	1	1	1	1	1	1
 0	0.12	0.54	0.66	0.81	1	1	1	1	1	1	1	1	1	1
 
 #input_survey_selectivity(1,ns,1,nreg,1,na,1,nf)
+0	0.12	0.54	0.66	0.81	1	1	1	1	1	1	1	1	1	1
+0	0.12	0.54	0.66	0.81	1	1	1	1	1	1	1	1	1	1
 0	0.35	0.61	0.54	0.66	1	1	1	1	1	1	1	1	1	1
 0	0.35	0.61	0.54	0.66	1	1	1	1	1	1	1	1	1	1
 #q_survey(by population, area and fleet)
 1
 1
+1
+1
 #input_F
+0.2
+0.2
 0.2
 0.2
 #start year of fishery (F before this ==0) and min and max F for Dunce Cap F option ==9
@@ -257,15 +420,22 @@
 #F_rho (degree of autocorrelation in F random walk
 1
 1
+1
+1
 #F_MSY
 0.5
 #input_M
 0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226
+0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226
 #sigma_recruit
+1.4
 1.4
 #sigma_rec_prop #error around recruit appotionment
 0.2
+0.2
 #sigma_F: used for random walk F and random devs around dunce cap F
+0.0
+0
 0.0
 0.0
 ##########################################################################################################################################
@@ -279,14 +449,22 @@
 #input_weight
 0.101	0.273	0.377	0.473	0.545	0.622	0.674	0.754	0.805	0.833	0.909	0.952	0.938	0.918	0.982
 0.101	0.273	0.377	0.473	0.545	0.622	0.674	0.754	0.805	0.833	0.909	0.952	0.938	0.918	0.982
+0.101	0.273	0.377	0.473	0.545	0.622	0.674	0.754	0.805	0.833	0.909	0.952	0.938	0.918	0.982
+0.101	0.273	0.377	0.473	0.545	0.622	0.674	0.754	0.805	0.833	0.909	0.952	0.938	0.918	0.982
 #input_catch_weight
+0.101	0.273	0.377	0.473	0.545	0.622	0.674	0.754	0.805	0.833	0.909	0.952	0.938	0.918	0.982
+0.101	0.273	0.377	0.473	0.545	0.622	0.674	0.754	0.805	0.833	0.909	0.952	0.938	0.918	0.982
 0.101	0.273	0.377	0.473	0.545	0.622	0.674	0.754	0.805	0.833	0.909	0.952	0.938	0.918	0.982
 0.101	0.273	0.377	0.473	0.545	0.622	0.674	0.754	0.805	0.833	0.909	0.952	0.938	0.918	0.982
 #fecundity
 0 0.12 0.54 0.71 0.87 1 1 1 1 1 1 1 1 1 1
+0 0.12 0.54 0.71 0.87 1 1 1 1 1 1 1 1 1 1
+0 0.12 0.54 0.71 0.87 1 1 1 1 1 1 1 1 1 1
 0 0.12 0.54 0.71 0.87 1 1 1 1 1 1 1 1 1 1 
 #maturity
 0	0.41	0.69	0.84	0.98	1	1	1	1	1	1	1	1	1	1
+0	0.41	0.69	0.84	0.98	1	1	1	1	1	1	1	1	1	1
+0.32	0.79	0.88	0.94	0.98	1	1	1	1	1	1	1	1	1	1
 0.32	0.79	0.88	0.94	0.98	1	1	1	1	1	1	1	1	1	1
 ##########################################################################################################################################
 #########################################################################################################################################
@@ -296,46 +474,91 @@
 #prop_fem
 0.5
 0.5
+0.5
+0.5
 #input_Rec_prop
+0.9
 0.1
 0.9
+0.1
 
 #Equil_ssb_apportion
+.2612
+.7388
 .2612
 .7388
 
 #init_abund
 1562500	1246434.534	994303.3902	793173.8129	632729.1083	504739.4632	402639.8064	321193.062	256221.5197	204392.5443	163047.6324	130066.0478	103756.0408	82768.07187	66025.58917
 1562500	1246434.534	994303.3902	793173.8129	632729.1083	504739.4632	402639.8064	321193.062	256221.5197	204392.5443	163047.6324	130066.0478	103756.0408	82768.07187	66025.58917
+1562500	1246434.534	994303.3902	793173.8129	632729.1083	504739.4632	402639.8064	321193.062	256221.5197	204392.5443	163047.6324	130066.0478	103756.0408	82768.07187	66025.58917
+1562500	1246434.534	994303.3902	793173.8129	632729.1083	504739.4632	402639.8064	321193.062	256221.5197	204392.5443	163047.6324	130066.0478	103756.0408	82768.07187	66025.58917
+1562500	1246434.534	994303.3902	793173.8129	632729.1083	504739.4632	402639.8064	321193.062	256221.5197	204392.5443	163047.6324	130066.0478	103756.0408	82768.07187	66025.58917
+1562500	1246434.534	994303.3902	793173.8129	632729.1083	504739.4632	402639.8064	321193.062	256221.5197	204392.5443	163047.6324	130066.0478	103756.0408	82768.07187	66025.58917
+1562500	1246434.534	994303.3902	793173.8129	632729.1083	504739.4632	402639.8064	321193.062	256221.5197	204392.5443	163047.6324	130066.0478	103756.0408	82768.07187	66025.58917
+1562500	1246434.534	994303.3902	793173.8129	632729.1083	504739.4632	402639.8064	321193.062	256221.5197	204392.5443	163047.6324	130066.0478	103756.0408	82768.07187	66025.58917
 #rec_index_sigma
+0.5
+0.5
 0.5
 0.5
 #sigma_survey
 0.2
 0.2
+0.2
 #sigma_survey_overlap
+0.2
+0.2
+0.2
+0.2
+0.2
+0.2
 0.2
 0.2
 #sigma_catch
 0.05
 0.05
+0.05
+0.05
 #sigma_catch_overlap
+0.05
+0.05
+0.05
+0.05
+0.05
+0.05
 0.05
 0.05
 #SIM_ncatch
 #//cannot exceed 2000, otherwise change dimension of associated temp vector in parameter section
 50
-1000
+50
+50
+50
 #SIM_ncatch_overlap
 #//cannot exceed 2000, otherwise change dimension of associated temp vector in parameter section
+100
+100
+100
+100
+100
+100
 100
 100
 #SIM_nsurvey
 #//cannot exceed 2000, otherwise change dimension of associated temp vector in parameter section
 50
 50
+50
+50
 #SIM_nsurvey_overlap
 #//cannot exceed 2000, otherwise change dimension of associated temp vector in parameter section
+50
+50
+50
+50
+50
+50
 50
 50
 #input_TAC
@@ -346,8 +569,12 @@
 ### IF PARSE TAC OR U USING OBS DATA THEN MAKE SURE THAT FULL TAC OR U FOR THAT AREA IS INPUT FOR EACH FLEET IN THAT AREA ###
 ########################################################################################################
 1
-1 
+1
+1
+1
 #input_u 
+.0491
+.0491
 .0491
 .0491
 ################################################################################################################
@@ -383,3 +610,5 @@
 600000
 #myseed_catch_age
 700000
+#myseed_tag
+800000


### PR DESCRIPTION
Added the tagging component to the simulation model.  I think I included all aspects that were discussed at the meeting.  I've tested this for 1 pop, 2 regions and 2 pops, 2 regs and everything looked good.  Note that I tried running the model with 2 pops and uneven regions per pop and I ran into some errors (before the tag function), so we probably want to avoid having different numbers of regions for each populations (I believe this is a problem with the ragged arrays, which may not be an easy fix).

We can input the number of years that we want tagging to occur along with the specific years of each tagging event (i.e., you input the total number of release events and the years that these events occur), so it is flexible for any number of tagging scenarios.  In addition, you input the fraction of total abundance that you want to tag in each release event.  The model then calculates how many tags this corresponds to, then apportions to population based on relative bio.  Within each population, tags are then reapportioned to region based on relative bio.  

Recaptures are followed for a input number of years (assumed to be based on life history..ie longevity).  Reporting rate is input and can be specific to the population, region, and release event (I didn't want to have to input recapture year specific values).  It is assumed that fish are tagged in their 'natal' population (i.e., during spawning), so we don't have to keep track of natal population (it is assumed known by their release location).  For natal homing, tag dynamics (i.e., movement) are defined by the natal population not the current population.

A multinomial likelihood is used to simulate observed recaptures with error.  An input ESS is used to define the variance of the distribution.  It is constant across release events, etc... (just a single number).

Brian: Outputs are multidimensional ragged arrays so will likely need to do same thing in report section that do for catch, etc... to avoid misprinting in report file.

Dana, Jon, etc...: Whoever codes the estimation model should note that when comparing obs/pred recaps, we may have ages with no releases (since apportion tags using selectivity of the survey and survey selectivity is often 0 for younger ages).  I suggest using an if statement in the likelihood section that says: 
if (ntags==0){nll_tags(j,r,x,a...)=0}

We don't want this data affecting the likelihood given that they are not 'real' zeros.  They just represent no data.

Other notes:

age is accounted for in releases, so not explicitly included in recaps (implicit in recap year)...also no plus group calc because cut off tag recaps at input max_tag_life, therefore calcs will use movement and mortality values for plus group age (i.e., max age) in tag_recap and tag_avail calcs