### PR TITLE
Update the TIM OM tpl file into the master branch

### DIFF
--- a/Tag_Integrated_Model/Operating_Model/CODE_TO_ALTER_Spatial_BRP.tpl
+++ b/Tag_Integrated_Model/Operating_Model/CODE_TO_ALTER_Spatial_BRP.tpl
@@ -330,6 +330,9 @@ DATA_SECTION
   int d
   int xx
 
+//Add counters to enumerate the regions for the report out section for 6d arrays
+  int region_counter
+
  !! cout << "debug = " << debug << endl;
  !! cout << "If debug != 1541 then .dat file not setup correctly" << endl;
  !! cout << "input read" << endl;
@@ -621,6 +624,23 @@ PARAMETER_SECTION
  3darray rec_index_RN(1,nps,1,nr,1,nyr)
 
  init_number dummy(phase_dummy)
+
+///////////////////////////////////////////////////////////////////////////////////////////////
+//Temporary (reorganized) 6d arrary parameters 
+//Reorganize so that region is the second dimension. 
+//////////////////////////////////////////////////////////////////////////////////////////////
+//survey index  
+ 6darray ro_true_survey_fleet_overlap_age(1,nps,1,nr,1,nps,1,nyr,1,nfls,1,nag) 
+ 6darray ro_survey_at_age_region_fleet_overlap_prop(1,nps,1,nr,1,nps,1,nfls,1,nyr,1,nag) 
+ 6darray ro_SIM_survey_prop_overlap(1,nps,1,nr,1,nps,1,nfls,1,nyr,1,nag)
+ 6darray ro_OBS_survey_prop_overlap(1,nps,1,nr,1,nps,1,nfls,1,nyr,1,nag)
+ 6darray ro_true_survey_fleet_overlap_age_bio(1,nps,1,nr,1,nps,1,nyr,1,nfls,1,nag) 
+//yield & BRP calcs 
+ 6darray ro_catch_at_age_region_fleet_overlap(1,nps,1,nr,1,nps,1,nfl,1,nyr,1,nag) 
+ 6darray ro_catch_at_age_region_fleet_overlap_prop(1,nps,1,nr,1,nps,1,nfl,1,nyr,1,nag)
+ 6darray ro_SIM_catch_prop_overlap(1,nps,1,nr,1,nps,1,nfl,1,nyr,1,nag) 
+ 6darray ro_OBS_catch_prop_overlap(1,nps,1,nr,1,nps,1,nfl,1,nyr,1,nag) 
+
 
   objective_function_value f
 
@@ -5133,10 +5153,6 @@ FUNCTION evaluate_the_objective_function
 REPORT_SECTION
  //report<<"$recaps"<<endl;
  //report<<recaps<<endl;
- //report<<"$True_tag_prop"<<endl; // 5-D array not reading in with R so comment out
- //report<<tag_prop_final<<endl;  //5-D array not reading in with R so comment out
- //report<<"$OBS_tag_prop"<<endl;  //5-D array not reading in with R so comment out
- //report<<OBS_tag_prop_final<<endl;  //5-D array not reading in with R so comment out
  // report<<"$biomass_BM_age"<<endl;
  // report<<biomass_BM_age<<endl;
  // report<<"$Fract_Move_DD"<<endl;
@@ -5162,10 +5178,10 @@ REPORT_SECTION
   report<<npops<<endl;
   report<<"$nregions"<<endl;
   report<<nregions<<endl;
-  report<<"$nages"<<endl;
-  report<<nages<<endl;
   report<<"$nfleets"<<endl;
   report<<nfleets<<endl;
+  report<<"$nfleets_survey"<<endl;
+  report<<nfleets_survey<<endl;
 
   report<<"$larval_move_switch"<<endl;
   report<<larval_move_switch<<endl;
@@ -5434,8 +5450,6 @@ REPORT_SECTION
   report<<"$OBS_survey_total_bio"<<endl;
   report<<OBS_survey_total_bio<<endl;
 
-  //report<<"$true_survey_fleet_bio_overlap"<<endl; //5-D array not reading in with R so comment out
-  //report<<true_survey_fleet_bio_overlap<<endl;  //5-D array not reading in with R so comment out
   report<<"$true_survey_region_bio_overlap"<<endl;
   report<<true_survey_region_bio_overlap<<endl;
   report<<"$true_survey_population_bio_overlap"<<endl;
@@ -5445,8 +5459,6 @@ REPORT_SECTION
   report<<"$true_survey_total_bio_overlap"<<endl;
   report<<true_survey_total_bio_overlap<<endl;
 
-  //report<<"$OBS_survey_fleet_bio_overlap"<<endl; //5-D array not reading in with R so comment out 
-  //report<<OBS_survey_fleet_bio_overlap<<endl;  //5-D array not reading in with R so comment out
   report<<"$OBS_survey_region_bio_overlap"<<endl;
   report<<OBS_survey_region_bio_overlap<<endl;
   report<<"$OBS_survey_population_bio_overlap"<<endl;
@@ -5484,8 +5496,6 @@ REPORT_SECTION
   report<<"$SSB_natal_overlap"<<endl;
   report<<SSB_natal_overlap<<endl;
 
-  //report<<"$yield_region_fleet_overlap"<<endl; //5-D array not reading in with R so comment out
-  //report<<yield_region_fleet_overlap<<endl;  //5-D array not reading in with R so comment out
   report<<"$yield_region_overlap"<<endl;
   report<<yield_region_overlap<<endl;
   report<<"$yield_population_overlap"<<endl;
@@ -5493,8 +5503,6 @@ REPORT_SECTION
   report<<"$yield_natal_overlap"<<endl;
   report<<yield_natal_overlap<<endl;
 
-  //report<<"$OBS_yield_region_fleet_overlap"<<endl; //5-D array not reading in with R so comment out
-  //report<<OBS_yield_region_fleet_overlap<<endl; //5-D array not reading in with R so comment out
   report<<"$OBS_yield_region_overlap"<<endl;
   report<<OBS_yield_region_overlap<<endl;
   report<<"$OBS_yield_population_overlap"<<endl;
@@ -5536,6 +5544,178 @@ REPORT_SECTION
   report<<Bratio_natal_overlap<<endl;
 
 
+///////////////////////////////////////////////////////////////////////////
+  //Reorganization and report-out section
+  //Used so that R can read 5d and 6d arrarys. 
+  //Index by population and region for 6d arrarys (and input_T), 
+  //by population for 5d arrays.
+  //Requires reorganizing some 6d array variables
+  //Exclude 5d and 6d array "temp" variables because they are not needed
+///////////////////////////////////////////////////////////////////////////
+  if(npops>1 || nregions[1]>1) //more than one population or if one population, more than 1 region within that population. Fleets are restricted to be one fleet per region
+  {
+  //////////////////////////
+  //Reorganize
+  //////////////////////////
+  //Assigns original parameter names to reorganized (ro) parameter names with either population and region at the beginning
+  //or with age removed entirely
+    for (int p=1;p<=npops;p++)
+    {
+     for (int j=1;j<=npops;j++)
+      {
+       for (int r=1;r<=nregions(p);r++)
+        {
+         for (int a=1;a<=nages;a++)
+          {
+           for(int x=1;x<=nfleets(p);x++)
+            {
+             for(int y=1;y<=nyrs;y++)
+              {
+               for(int z=1;z<=nfleets_survey(p);z++)
+                {
+                //6D arrary
+                 //survey index
+                 ro_true_survey_fleet_overlap_age(p,r,j,y,z,a) = true_survey_fleet_overlap_age(p,j,r,y,z,a);
+                 ro_survey_at_age_region_fleet_overlap_prop(p,r,j,z,y,a) = survey_at_age_region_fleet_overlap_prop(p,j,r,z,y,a);
+                 ro_SIM_survey_prop_overlap(p,r,j,z,y,a) = SIM_survey_prop_overlap(p,j,r,z,y,a);
+                 ro_OBS_survey_prop_overlap(p,r,j,z,y,a) = OBS_survey_prop_overlap(p,j,r,z,y,a);
+                 ro_true_survey_fleet_overlap_age_bio(p,r,j,y,z,a) = true_survey_fleet_overlap_age_bio(p,j,r,y,z,a);
+                 //yield & BRP calcs 
+                 ro_catch_at_age_region_fleet_overlap(p,r,j,x,y,a) = catch_at_age_region_fleet_overlap(p,j,r,x,y,a);
+                 ro_catch_at_age_region_fleet_overlap_prop(p,r,j,x,y,a) = catch_at_age_region_fleet_overlap_prop(p,j,r,x,y,a);
+                 ro_SIM_catch_prop_overlap(p,r,j,x,y,a) = SIM_catch_prop_overlap(p,j,r,x,y,a);
+                 ro_OBS_catch_prop_overlap(p,r,j,x,y,a) = OBS_catch_prop_overlap(p,j,r,x,y,a);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  ////////////////////////////
+  //Report out 
+  //All 5D and 6D arrays, both those reorganized and those not
+  ////////////////////////////
+    //Since regions are by population, need to include in population loop
+    //Thus, need counters to index total number of regions.
+    //For example, with region, for 3 pops with 2 1 and 1 regions, region1 is region 1 of pop 1, 
+    //region2 is region 2 of pop 1, region3 is region 1 of pop 2, and region4 is region 1 of pop 3. 
+    region_counter=1;
+    for (int p=1;p<=npops;p++)
+     {
+      for (int r=1;r<=nregions(p);r++)
+        {
+         //6d arrays. Output population-region
+         //vitals
+         report<<"$alt_T_"<<region_counter<<endl;
+         report<<T[p][r]<<endl;
+         report<<"$alt_rel_bio_"<<region_counter<<endl;
+         report<<rel_bio[p][r]<<endl;
+         //survey index
+         report<<"$ro_true_survey_fleet_overlap_age_"<<region_counter<<endl;         
+         report<<ro_true_survey_fleet_overlap_age[p][r]<<endl;                       
+         report<<"$ro_survey_at_age_region_fleet_overlap_prop_"<<region_counter<<endl; 
+         report<<ro_survey_at_age_region_fleet_overlap_prop[p][r]<<endl;               
+         report<<"$ro_SIM_survey_prop_overlap_"<<region_counter<<endl;
+         report<<ro_SIM_survey_prop_overlap[p][r]<<endl;
+         report<<"$ro_OBS_survey_prop_overlap_"<<region_counter<<endl;
+         report<<ro_OBS_survey_prop_overlap[p][r]<<endl;
+         report<<"$ro_true_survey_fleet_overlap_age_bio_"<<region_counter<<endl;
+         report<<ro_true_survey_fleet_overlap_age_bio[p][r]<<endl;
+         //yield & BRP calcs 
+         report<<"$ro_catch_at_age_region_fleet_overlap_"<<region_counter<<endl;
+         report<<ro_catch_at_age_region_fleet_overlap[p][r]<<endl;
+         report<<"$ro_catch_at_age_region_fleet_overlap_prop_"<<region_counter<<endl; 
+         report<<ro_catch_at_age_region_fleet_overlap_prop[p][r]<<endl;               
+         report<<"$ro_SIM_catch_prop_overlap_"<<region_counter<<endl;
+         report<<ro_SIM_catch_prop_overlap[p][r]<<endl;
+         report<<"$ro_OBS_catch_prop_overlap_"<<region_counter<<endl;
+         report<<ro_OBS_catch_prop_overlap[p][r]<<endl; 
+         //DATA SECTION
+         report<<"$alt_input_T_"<<region_counter<<endl;
+         report<<input_T[p][r]<<endl;
+
+         //7D array tagging variables
+         for(int x=1;x<=nyrs_release;x++)
+          {
+           report<<"$alt_tags_avail_reg"<<region_counter<<"_rel"<<x<<endl;
+           report<<tags_avail[p][r][x]<<endl;
+           report<<"$alt_recaps_reg"<<region_counter<<"_rel"<<x<<endl;
+           report<<recaps[p][r][x]<<endl;
+           report<<"$alt_tag_prop_reg"<<region_counter<<"_rel"<<x<<endl;
+           report<<tag_prop[p][r][x]<<endl;
+          }
+
+         region_counter++;
+        }
+        
+      //5d arrays. Output population
+      //Observed yield
+      report<<"$alt_OBS_yield_region_fleet_overlap_"<<p<<endl;
+      report<<OBS_yield_region_fleet_overlap[p]<<endl;
+      report<<"$alt_yield_RN_overlap_"<<p<<endl;
+      report<<yield_RN_overlap[p]<<endl;
+      report<<"$alt_survey_RN_overlap_"<<p<<endl;
+      report<<survey_RN_overlap[p]<<endl;
+      //yield & BRP calcs
+      report<<"$alt_abundance_spawn_overlap_"<<p<<endl;
+      report<<abundance_spawn_overlap[p]<<endl;
+      report<<"$alt_catch_at_age_region_overlap_"<<p<<endl;
+      report<<catch_at_age_region_overlap[p]<<endl;
+      report<<"$alt_catch_at_age_region_overlap_prop_"<<p<<endl;      
+      report<<catch_at_age_region_overlap_prop[p]<<endl;              
+      report<<"$alt_biomass_BM_age_overlap_"<<p<<endl; //before
+      report<<biomass_BM_age_overlap[p]<<endl;  //before
+      report<<"$alt_biomass_AM_age_overlap_"<<p<<endl; 
+      report<<biomass_AM_age_overlap[p]<<endl; 
+      report<<"$alt_abundance_at_age_BM_overlap_region_"<<p<<endl; 
+      report<<abundance_at_age_BM_overlap_region[p]<<endl;
+      report<<"$alt_abundance_at_age_AM_overlap_region_"<<p<<endl;
+      report<<abundance_at_age_AM_overlap_region[p]<<endl;
+      report<<"$alt_catch_at_age_fleet_prop_"<<p<<endl;               
+      report<<catch_at_age_fleet_prop[p]<<endl;                       
+      report<<"$alt_SIM_catch_prop_"<<p<<endl;                        
+      report<<SIM_catch_prop[p]<<endl;                                
+      report<<"$alt_OBS_catch_prop_"<<p<<endl;                        
+      report<<OBS_catch_prop[p]<<endl;                                
+      report<<"$alt_yield_region_fleet_overlap_"<<p<<endl;            
+      report<<yield_region_fleet_overlap[p]<<endl;                    
+      report<<"$alt_harvest_rate_region_fleet_bio_overlap_"<<p<<endl;           
+      report<<harvest_rate_region_fleet_bio_overlap[p]<<endl;         
+      report<<"$alt_catch_at_age_fleet_"<<p<<endl;                    
+      report<<catch_at_age_fleet[p]<<endl;                            
+      //survey index
+      report<<"$alt_true_survey_fleet_age_"<<p<<endl;
+      report<<true_survey_fleet_age[p]<<endl;
+      report<<"$alt_survey_at_age_fleet_prop_"<<p<<endl;
+      report<<survey_at_age_fleet_prop[p]<<endl;
+      report<<"$alt_SIM_survey_prop_"<<p<<endl;
+      report<<SIM_survey_prop[p]<<endl;
+      report<<"$alt_OBS_survey_prop_"<<p<<endl;
+      report<<OBS_survey_prop[p]<<endl;
+      report<<"$alt_true_survey_fleet_age_bio_"<<p<<endl;
+      report<<true_survey_fleet_age_bio[p]<<endl; 
+      report<<"$alt_survey_selectivity_"<<p<<endl;
+      report<<survey_selectivity[p]<<endl;
+      report<<"$alt_true_survey_fleet_bio_overlap_"<<p<<endl;
+      report<<true_survey_fleet_bio_overlap[p]<<endl;
+      report<<"$alt_OBS_survey_fleet_bio_overlap_"<<p<<endl;
+      report<<OBS_survey_fleet_bio_overlap[p]<<endl;
+      //vitals
+      report<<"$alt_selectivity_"<<p<<endl;
+      report<<selectivity[p]<<endl;
+      report<<"$alt_F_fleet_"<<p<<endl;
+      report<<F_fleet[p]<<endl; 
+      //tagging variables
+      report<<"$alt_tag_prop_final_"<<p<<endl;
+      report<<tag_prop_final[p]<<endl;
+      report<<"$alt_SIM_tag_prop_"<<p<<endl;
+      report<<SIM_tag_prop[p]<<endl;
+      report<<"$alt_OBS_tag_prop_final_"<<p<<endl;
+      report<<OBS_tag_prop_final[p]<<endl;
+     }
+   }
   
 RUNTIME_SECTION
   convergence_criteria .001,.0001, 1.0e-4, 1.0e-7


### PR DESCRIPTION
Updated so that all 5d+ arrays could  be read using R. 

Things added to SPASAM\Tag_integrated_model\Operating_Model:

1.	Added report out of “nfleets_survey”

2.	Removed extra report out of “nages”

3.	Remove report out of “tag_prop_final” and “OBS_tag_prop” since these are 5d arrays and I report them out with formatting described in point 5.

4.	Removed four more variables in the report section that would cause issues when reading in the report file because they were 5d arrays. These were true_survey_fleet_bio_overlap, OBS_survey_fleet_bio_overlap, yield_region_fleet_overlap, OBS_yield_region_fleet_overlap. These variable were included in point 5, below.  

5.	5d and 6d arrays
Reorganized all 6d arrays that aren’t temporary: 
renamed variables to start with ‘ro’, and redefined so that the first two dimensions are population from and region, as opposed to population from and population to. For 6d vital arrays, dimensions were already population from and region, so did not need to reorganize. Outputted as 4d arrays indexed by the region number (region 1 = pop 1 region 1; region 2 = pop 1 region 2 (or pop 2 region 1 is single regions per pop; etc.) with naming convention of “_X” at the end where X is the region number, which required indexing over region and population (from) dimensions. 

Outputted all 5d arrays that aren’t temporary:
outputted as 4d arrays indexed by the population number with naming convention of “_Y” at the end where Y is the population number of the first (population from) dimension, and “alt_” at the beginning. For input_T, although it’s a 5d array, I had to index over population and region because I was getting reading issues into R when indexing only over pop, thus output for it is in a 3d array, and it’s named with “alt_” in the beginning and “_X” at the end where X is the region number.

6.	7D tagging arrays
Outputted as 4d arrays indexed by the region number (region 1 = pop 1 region 1; region 2 = pop 1 region 2 (or pop 2 region 1 is single regions per pop; etc.) and the year of tag releases, with naming convention of “_regX_relZ” at the end where X is the region number, which required indexing over region and population (from) dimensions, and Z is the release year

Hence, anything starting with “ro_” had its dimensions reorganized and reduced, whereas anything starting with “alt_” only had its dimensions reduced.
