### PR TITLE
Use true values in likelihood

### DIFF
--- a/Tag_Integrated_Model/Operating_Model/TIM_OM.dat
+++ b/Tag_Integrated_Model/Operating_Model/TIM_OM.dat
@@ -5,19 +5,22 @@
 #   // ==1 the OM is metamictic
 #   // ==2 the OM is metapop
 #   // ==3 the OM is natal homing - not there yet...
-1
+2
 
 #nages
 15
 #nyrs
 40 #10 JJD
 #npopulations
-1
-#nregions
 2
+#nregions
+1
+1
 #nfleets
 1
+1
 #nfleets_survey
+1
 1
 #model_type_switch
   #==0 do not use TAC to set F
@@ -27,7 +30,7 @@
 #do_tag
   #==0 do not calculate tagging data
   #==1 calculate tagging data
-1
+0
 # parse_TAC
   #==0 do not alter the input TAC or harvest rate
   #==1 use observed data source to parse TAC or harvest rate (used when allocating harvest but pop structure unknown)
@@ -91,6 +94,7 @@
   #==8 density dependent movement based on relative biomass among potential destination area/regions, partitions (1-input_residency) based on a logistic function of biomass in current area/region and 'suitability' of destination area/regions
   #//uses use_input_Bstar switch 
 1
+
 #use_input_Bstar
   #==0 set Bstar for DD movement equal to SSB_zero*SSB_zero_appor (if nreg==1, Bstar=SSB0), **NOTE** for Rec_type!=2 (not BH), defaults to using input_Bstar since no SSB0 calcs are done
   #==1 use input_Bstar
@@ -234,7 +238,9 @@
 4
 #return_probability- probability of returning for move_switch==6
 1
+1
 #spawn_return_prob - probability of returning for spawning if overlap_switch==2
+1
 1
 #phase_F - must be turned on (==1) if F_type==3
 -1
@@ -242,13 +248,18 @@
 1
 #tspawn in proportion of year (0-1)
 0
+0
 #steep
+0.814
 0.814
 #R_ave - on the log scale please!
 6.656849
+6.656849
 #amplitude - amplitude of occilations for recritment variation. Use when Rec_type ==3
 0.2
+0.2
 #freq - period of ossilation for recruitment variation. Use when Rec_type ==3
+15
 15
 
 #input_T (1,np,1,nreg,1,na,1,np,1,nreg)
@@ -340,9 +351,12 @@
 0.5
 #input_M
 0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226
+0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226
 #sigma_recruit
 0.4
+0.4
 #sigma_rec_prop #error around recruit apportionment
+0.2
 0.2
 #sigma_F
 0.35
@@ -375,46 +389,55 @@
 0.6
 0.4
 #input_Rec_prop
-0.6
-0.4
+1
+1
 #Equil_ssb_apportion
 0.6
 0.4
 #init_abund
 1562.5	1246.434534	994.3033902	793.1738129	632.7291083	504.7394632	402.6398064	321.193062	256.2215197	204.3925443	163.0476324	130.0660478	103.7560408	82.76807187	66.02558917
+0	0	0	0	0	0	0	0	0	0	0	0	0	0	0
+0	0	0	0	0	0	0	0	0	0	0	0	0	0	0
 1562.5	1246.434534	994.3033902	793.1738129	632.7291083	504.7394632	402.6398064	321.193062	256.2215197	204.3925443	163.0476324	130.0660478	103.7560408	82.76807187	66.02558917
 #rec_index_sigma
-0.005
-0.005
+0.1
+0.1
 #sigma_survey
-0.002
-0.002
+0.1
+0.1
 #sigma_survey_overlap
-0.002
-0.002
+0.1
+0.1
+0.1
+0.1
 #sigma_catch
-0.0005
-0.0005
+0.05
+0.05
 #sigma_catch_overlap
-0.0005
-0.0005
+0.05
+0.05
+0.05
+0.05
 #SIM_ncatch
 #//cannot exceed 2000, otherwise change dimension of associated temp vector in parameter section
-1000
-1000
+100
+100
 #SIM_ncatch_overlap
 #//cannot exceed 2000, otherwise change dimension of associated temp vector in parameter section
-1000
-1000
+100
+100
+100
+100
 #SIM_nsurvey
 #//cannot exceed 2000, otherwise change dimension of associated temp vector in parameter section
-1000
-1000
+100
+100
 #SIM_nsurvey_overlap
 #//cannot exceed 2000, otherwise change dimension of associated temp vector in parameter section
-1000
-1000
-
+100
+100
+100
+100
 #input_TAC
  #TAC that are matching if model_type_switch==1
 ################################################################################################################
@@ -455,19 +478,27 @@
   # ==0 the EM is panmictic
   # ==1 the EM is metamictic
   # ==2 the EM is metapop
-1
+2
 
 #npops_EM
-1
-#nregions_EM
 2
+#nregions_EM
+1
+1
 #nfleets_EM
 1
+1
 #nfleets_survey_EM
+1
 1
 #tsurvey_EM
 0
 0
+#diagnostics_switch
+  #==0 allow OBS data to be used for estimation
+  #==1 allow TRUE data from without error to be used for estimation
+0
+
 #larval_move_switch
   #==0 no movement
   #==1 input movement
@@ -561,17 +592,21 @@
 
 #tspawn_EM(1,np_em)
 0
+0
 
 #return_probability_EM(1,np_em)
 1
+1
 
 #spawn_return_prob_EM(1,np_em)
+1
 1
 
 #do_tag
   #==0 do not calculate tagging data
   #==1 calculate tagging data
 1
+
 #do_tag_mult
   #==0 assume neg binomial distribution for tagging data
   #==1 assume multinomial distribution (same as OM)
@@ -611,12 +646,17 @@
 
 #sigma_rec_em(1,np_em)
 0.4
+0.4
 
 #init_abund_EM(1,np_em,1,np_em,1,nreg_em,1,na)
 1562.5	1246.434534	994.3033902	793.1738129	632.7291083	504.7394632	402.6398064	321.193062	256.2215197	204.3925443	163.0476324	130.0660478	103.7560408	82.76807187	66.02558917
+0	0	0	0	0	0	0	0	0	0	0	0	0	0	0
+0	0	0	0	0	0	0	0	0	0	0	0	0	0	0
 1562.5	1246.434534	994.3033902	793.1738129	632.7291083	504.7394632	402.6398064	321.193062	256.2215197	204.3925443	163.0476324	130.0660478	103.7560408	82.76807187	66.02558917
 
+
 #input_M_EM(1,np_em,1,na)
+0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226
 0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226	0.226
 
 #report_rate(1,ny_rel,1,np_em,1,nreg_em)
@@ -638,7 +678,7 @@
 #ph_init_abund
 -1
 #ph_F
--3
+3
 #ph_steep
 -1
 #ph_M
@@ -666,7 +706,7 @@
 #ph_T_YR
 -5
 #ph_T_CNST
--4
+4
 #ph_dummy
 1
 
@@ -685,6 +725,7 @@
 1
 #wt_tag
 1
+
 #abund_pen_switch
  #// include penalty (norm2) on init_abund_devs?  0==no, 1==yes
  #//==0 no move pen in log space
@@ -704,20 +745,19 @@
 
 #controlling error for the EM
 #OBS_survey_fleet_se(1,np_em,1,nreg_em,1,ny,1,nf_em)  #standard errors
-0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02
-0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02 0.02
-
+0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2
+0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2
 #OBS_yield_fleet_se(1,np_em,1,nreg,1,ny,1,nf_em)  #standard errors
-0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05
-0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05 0.05
+0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2
+0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2 0.2
 
 #OBS_survey_prop_N(1,np_em,1,nreg_em,1,ny,1,nfs_em) #number of survey ages
-1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000
-1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000
-
+100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100
+100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100
 #OBS_catch_at_age_fleet_prop_N(1,np_em,1,nreg_em,1,ny,1,nfs) //fishery sample size ages
-1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000
-1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000
+100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100
+100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100
+
 
 #tag_N(1,np_em,1,nreg_em,1,ny_rel,1,na) //fishery sample size ages
 100 100 100 100 100 100 100 100 100 100 100 100 100 100 100

--- a/Tag_Integrated_Model/Operating_Model/TIM_OM.tpl
+++ b/Tag_Integrated_Model/Operating_Model/TIM_OM.tpl
@@ -342,6 +342,10 @@ DATA_SECTION
 
   init_matrix tsurvey_EM(1,np_em,1,nreg_em)
 
+  init_number diagnostics_switch
+  //#==0 allow OBS data to be used for estimation
+  //#==1 allow TRUE data from without error to be used for estimation
+
   init_number larval_move_switch_EM
   ///// Changes the type of larval movement pattern (sets age class 1 movements)
   //==0 no movement
@@ -5708,6 +5712,8 @@ REPORT_SECTION
 //EM parameters input from OM .dat
   report<<"#tsurvey_EM"<<endl;
   report<<tsurvey_EM<<endl;
+  report<<"#diagnostics_switch"<<endl;
+  report<<diagnostics_switch<<endl;
   report<<"#larval_move_switch"<<endl;
   report<<larval_move_switch_EM<<endl;
   report<<"#move_switch"<<endl;
@@ -5982,6 +5988,18 @@ REPORT_SECTION
   report<<biomass_AM<<endl;
   report<<"#biomass_population"<<endl;
   report<<biomass_population<<endl;
+
+//add to EM input
+  report<<"#catch_at_age_fleet_prop"<<endl;
+  report<<catch_at_age_fleet_prop<<endl;
+  report<<"#yield_fleet"<<endl;
+  report<<yield_fleet<<endl;
+  report<<"#survey_at_age_fleet_prop"<<endl;
+  report<<survey_at_age_fleet_prop<<endl;
+  report<<"#true_survey_fleet_bio"<<endl;
+  report<<true_survey_fleet_bio<<endl;
+//
+
   report<<"#harvest_rate_region_bio"<<endl;
   report<<harvest_rate_region_bio<<endl;
   report<<"#depletion_region"<<endl;
@@ -5996,7 +6014,13 @@ REPORT_SECTION
   report<<selectivity_age<<endl;
   report<<"#survey_selectivity_age"<<endl;
   report<<survey_selectivity_age<<endl;
-  
+
+ //true tag information
+  report<<"#TRUE_tag_prop"<<endl;
+  report<<tag_prop_final<<endl;
+
+
+
   report<<"#debug"<<endl;
   report<<debug<<endl;
 


### PR DESCRIPTION
Updated the OM with diagnostics switch that allows true (without error) values for indices, age comps and tag proportion to be used in likelihoods.