### PR TITLE
Few improvements to diagnostic wrapper

### DIFF
--- a/Tag_Integrated_Model/R_wrappers/TIM_Diagnostics_master.R
+++ b/Tag_Integrated_Model/R_wrappers/TIM_Diagnostics_master.R
@@ -61,29 +61,37 @@ resid.switch=1
 ########### INPUTS FOR RUNNING MODELS ###########################################
 #################################################################################
   
+#name OPERATING MODEL of the .exe
+#OM_name<-OM_name #name of the OM you are wanting to run
+OM_name<-"TIM_OM" 
+
+#name ESTIMATION MODEL of the .exe
+#EM_name<-EM_name ###name of .dat, .tpl., .rep, etc.
+EM_name<-"TIM_EM" 
+
+
 #set the directory where the runs are held, make sure that each folder has the OM and EM folders with .tpl, .exe, .dat configured as desired
 
 # master file with holding the runs 
-direct_master<-"C:\\Users\\katelyn.bosley\\Desktop\\Tagging"
-
+direct_master<-"C:\\Users\\katelyn.bosley.NMFS\\Desktop\\3_TIM_Multi_Area"
 
 #list files in the directory
 files<-list.files(direct_master)
-  
+
+
 #select the file you want to run
 #if only running 1 folder set i to the number corresponding to the folder you want to run
-i=2
+i=1
   
-#if running the whole folder
+#if running the whole master folder
  #for(i in 1:length(files)){
 
-  #OM Location
+#OM Location
   OM_direct<-paste0(direct_master,"\\",files[i],"\\Operating_Model",sep="")
-  OM_name<-"TIM_OM" #name of the OM you are wanting to run
-  
-  #EM Location
+
+#EM Location
   EM_direct<-paste0(direct_master,"\\",files[i],"\\Estimation_Model",sep="") #location of run(s)
-  EM_name<-"TIM_EM" ###name of .dat, .tpl., .rep, etc.
+
 ###########################################################################
   
 
@@ -92,7 +100,13 @@ i=2
 ########### AUTOMATED...DO NOT CHANGE ######################################
 ############################################################################
 
-{ #run this section of code
+# One touch operation...run the whole code. Comment out this and very last bracket to run sections manually
+
+#{  
+  
+
+#running the OM and EM together
+ { 
 
 #run the OM
 setwd(OM_direct)
@@ -115,10 +129,15 @@ invisible(shell(paste0(EM_name),wait=T)))
 } #end running the OM/EM together
 
 
-
+  
 #########################################################
+#########################################################
+##### Ploting Code        ###############################
 ##### Look at the outputs ###############################
 #########################################################
+#########################################################
+  
+#plot and output function
 make.plots<-function(direct=EM_direct){ #run diagnostics plotting
   
 #Read in model .rep
@@ -1245,7 +1264,7 @@ tags.plot<-function(j) {
 ##############################################
 
 #for OM
-OM_dat<-readLines(paste0(OM_direct,"\\TIM_OM.dat"))
+OM_dat<-readLines(paste0(OM_direct,"\\",OM_name,".dat"))
 
 #create a table of values
 
@@ -1299,8 +1318,8 @@ OM_error_table[8,2:(1+nreg_OM)]<-OM_dat[nsurvey_om:(nsurvey_om+(nreg_OM-1))]
 OM_table<-tableGrob(OM_error_table)
 h <- grobHeight(OM_table)
 w <- grobWidth(OM_table)
-title <- textGrob("OM Error Params", y=unit(0.5,"npc") + 1.0*h, 
-                  vjust=0, gp=gpar(fontsize=12))
+title <- textGrob("OM Error Parameters", y=unit(0.5,"npc") + 1.0*h, 
+                  vjust=0, gp=gpar(fontsize=11))
 
 gt <- gTree(children=gList(OM_table, title))
 
@@ -1317,10 +1336,10 @@ gt <- gTree(children=gList(OM_table, title))
 ###########################################
 
 #did model converge?
-if(file.exists("TIM_EM.cor")==TRUE)
+if(file.exists(paste0(EM_name,".cor"))==TRUE)
      {cor.text<-paste("Model Converged")}
 
-if(file.exists("TIM_EM.cor")==FALSE)
+if(file.exists(paste0(EM_name,".cor"))==FALSE)
 {cor.text<-paste("Model did NOT Converge")}
 
 #max gradient
@@ -1328,11 +1347,12 @@ grad.val<-"Max gradient will eventually go here"
 
 
 
-tgrob.mod <- textGrob(paste(cor.text,grad.val,sep = "\n"),just = "centre")
+tgrob.mod <- textGrob(paste(cor.text," ",grad.val,sep = "\n"),just = "centre")
 
 ####################################################
 ##Table of True and Estimated values for parameters
 ####################################################
+
 {
 #Estimated parameter values
 # not set up for domed selectivity...can add that later
@@ -1345,17 +1365,59 @@ EM_est_table<-cbind(EM_est_table,temp_est)
 #params
 EM_est_table[1,2:ncol(EM_est_table)]<-round(out$q_survey,2)
 EM_est_table[2,2:ncol(EM_est_table)]<-round(out$R_ave,2)
-EM_est_table[3,2:ncol(EM_est_table)]<-round(out$sel_beta1,2)
-EM_est_table[4,2:ncol(EM_est_table)]<-round(out$sel_beta2,2)
-EM_est_table[5,2:ncol(EM_est_table)]<-round(out$sel_beta3,2)
-EM_est_table[6,2:ncol(EM_est_table)]<-round(out$sel_beta4,2)
+
+
+# adding in selectivity values based on specification
+if(OM_dat[grep("select_switch_EM",OM_dat, fixed = T)+4]==0)
+{
+  EM_est_table[3,2:ncol(EM_est_table)]<-NA
+  EM_est_table[4,2:ncol(EM_est_table)]<-NA
+  EM_est_table[5,2:ncol(EM_est_table)]<-NA
+  EM_est_table[6,2:ncol(EM_est_table)]<-NA
+}
+
+if(OM_dat[grep("select_switch_survey_EM",OM_dat, fixed = T)+4]==0)
+{
+  EM_est_table[7,2:ncol(EM_est_table)]<-NA
+  EM_est_table[8,2:ncol(EM_est_table)]<-NA
+  EM_est_table[9,2:ncol(EM_est_table)]<-NA
+  EM_est_table[10,2:ncol(EM_est_table)]<-NA
+}
+
+if(OM_dat[grep("select_switch_EM",OM_dat, fixed = T)+4]==1)
+{
+  EM_est_table[3,2:ncol(EM_est_table)]<-round(out$sel_beta1,2)
+  EM_est_table[4,2:ncol(EM_est_table)]<-round(out$sel_beta2,2)
+  EM_est_table[5,2:ncol(EM_est_table)]<-NA
+  EM_est_table[6,2:ncol(EM_est_table)]<-NA
+}
+
+if(OM_dat[grep("select_switch_survey_EM",OM_dat, fixed = T)+4]==1)
+{
+EM_est_table[7,2:ncol(EM_est_table)]<-round(out$sel_beta1_survey,2)
+EM_est_table[8,2:ncol(EM_est_table)]<-round(out$sel_beta2_survey,2)
+EM_est_table[9,2:ncol(EM_est_table)]<-NA
+EM_est_table[10,2:ncol(EM_est_table)]<-NA
+}
+
+if(OM_dat[grep("select_switch_EM",OM_dat, fixed = T)+4]==2)
+{
+  EM_est_table[3,2:ncol(EM_est_table)]<-round(out$sel_beta1,2)
+  EM_est_table[4,2:ncol(EM_est_table)]<-round(out$sel_beta2,2)
+  EM_est_table[5,2:ncol(EM_est_table)]<-round(out$sel_beta3,2)
+  EM_est_table[6,2:ncol(EM_est_table)]<-round(out$sel_beta4,2)
+}
+
+
+if(OM_dat[grep("select_switch_survey_EM",OM_dat, fixed = T)+4]==2)
+{
 EM_est_table[7,2:ncol(EM_est_table)]<-round(out$sel_beta1_survey,2)
 EM_est_table[8,2:ncol(EM_est_table)]<-round(out$sel_beta2_survey,2)
 EM_est_table[9,2:ncol(EM_est_table)]<-round(out$sel_beta3_survey,2)
 EM_est_table[10,2:ncol(EM_est_table)]<-round(out$sel_beta4_survey,2)
+}
 
-
-est_params<-tableGrob(EM_est_table)
+est_params<-tableGrob(EM_est_table,theme = ttheme_default(base_size = 11))
 h <- grobHeight(est_params)
 w <- grobWidth(est_params)
 title_est <- textGrob("Estimated Parameter Values", y=unit(0.5,"npc") + 1.0*h, 
@@ -1364,7 +1426,10 @@ title_est <- textGrob("Estimated Parameter Values", y=unit(0.5,"npc") + 1.0*h,
 gt_est <- gTree(children=gList(est_params, title_est))
 
 
+##################################
 #True Values
+#################################
+
 OM_true_table<-data.frame(Parameter=c("q","R_ave","beta 1 fishery","beta 2 fishery","beta 3 fishery","beta 4 fishery","beta 1 survey","beta 2 survey","beta 3 survey","beta 4 survey"))
 
 #set up matrix to fill in the values
@@ -1373,24 +1438,69 @@ names(temp_est)<-1:nreg
 OM_true_table<-cbind(OM_true_table,temp_est)
 OM_true_table[1,2:ncol(OM_true_table)]<-round(out$q_survey_TRUE,2)
 OM_true_table[2,2:ncol(OM_true_table)]<-round(out$R_ave_TRUE,2)
-OM_true_table[3,2:ncol(OM_true_table)]<-round(out$sel_beta1_TRUE,2)
-OM_true_table[4,2:ncol(OM_true_table)]<-round(out$sel_beta2_TRUE,2)
-OM_true_table[5,2:ncol(OM_true_table)]<-round(out$sel_beta3_TRUE,2)
-OM_true_table[6,2:ncol(OM_true_table)]<-round(out$sel_beta4_TRUE,2)
-OM_true_table[7,2:ncol(OM_true_table)]<-round(out$sel_beta1_survey_TRUE,2)
-OM_true_table[8,2:ncol(OM_true_table)]<-round(out$sel_beta2_survey_TRUE,2)
-OM_true_table[9,2:ncol(OM_true_table)]<-round(out$sel_beta3_survey_TRUE,2)
-OM_true_table[10,2:ncol(OM_true_table)]<-round(out$sel_beta4_survey_TRUE,2)
 
-true_params<-tableGrob(OM_true_table)
+
+# adding in selectivity values based on specification
+if(OM_dat[grep("select_switch_EM",OM_dat, fixed = T)+4]==0)
+{
+  OM_true_table[3,2:ncol(OM_true_table)]<-NA
+  OM_true_table[4,2:ncol(OM_true_table)]<-NA
+  OM_true_table[5,2:ncol(OM_true_table)]<-NA
+  OM_true_table[6,2:ncol(OM_true_table)]<-NA
+}
+
+if(OM_dat[grep("select_switch_survey_EM",OM_dat, fixed = T)+4]==0)
+{
+  OM_true_table[7,2:ncol(OM_true_table)]<-NA
+  OM_true_table[8,2:ncol(OM_true_table)]<-NA
+  OM_true_table[9,2:ncol(OM_true_table)]<-NA
+  OM_true_table[10,2:ncol(OM_true_table)]<-NA
+}
+
+if(OM_dat[grep("select_switch_EM",OM_dat, fixed = T)+4]==1)
+{
+  OM_true_table[3,2:ncol(OM_true_table)]<-round(out$sel_beta1_TRUE,2)
+  OM_true_table[4,2:ncol(OM_true_table)]<-round(out$sel_beta2_TRUE,2)
+  OM_true_table[5,2:ncol(OM_true_table)]<-NA
+  OM_true_table[6,2:ncol(OM_true_table)]<-NA
+}
+
+if(OM_dat[grep("select_switch_survey_EM",OM_dat, fixed = T)+4]==1)
+{
+  OM_true_table[7,2:ncol(OM_true_table)]<-round(out$sel_beta1_survey_TRUE,2)
+  OM_true_table[8,2:ncol(OM_true_table)]<-round(out$sel_beta2_survey_TRUE,2)
+  OM_true_table[9,2:ncol(OM_true_table)]<-NA
+  OM_true_table[10,2:ncol(OM_true_table)]<-NA
+}
+
+if(OM_dat[grep("select_switch_EM",OM_dat, fixed = T)+4]==2)
+{
+  OM_true_table[3,2:ncol(OM_true_table)]<-round(out$sel_beta1_TRUE,2)
+  OM_true_table[4,2:ncol(OM_true_table)]<-round(out$sel_beta2_TRUE,2)
+  OM_true_table[5,2:ncol(OM_true_table)]<-round(out$sel_beta3_TRUE,2)
+  OM_true_table[6,2:ncol(OM_true_table)]<-round(out$sel_beta4_TRUE,2)
+}
+
+
+if(OM_dat[grep("select_switch_survey_EM",OM_dat, fixed = T)+4]==2)
+{
+  OM_true_table[7,2:ncol(OM_true_table)]<-round(out$sel_beta1_survey_TRUE,2)
+  OM_true_table[8,2:ncol(OM_true_table)]<-round(out$sel_beta2_survey_TRUE,2)
+  OM_true_table[9,2:ncol(OM_true_table)]<-round(out$sel_beta3_survey_TRUE,2)
+  OM_true_table[10,2:ncol(OM_true_table)]<-round(out$sel_beta4_survey_TRUE,2)
+}
+
+true_params<-tableGrob(OM_true_table,theme = ttheme_default(base_size = 11))
 h <- grobHeight(true_params)
 w <- grobWidth(true_params)
 title_true <- textGrob("True Parameter Values", y=unit(0.5,"npc") + 1.0*h, 
                       vjust=0, gp=gpar(fontsize=12))
 
+
 gt_true <- gTree(children=gList(true_params, title_true))
 
 }
+
 
 ##########################################
 # SAVE THE OUTPUTS 
@@ -1463,10 +1573,6 @@ grid.arrange(ncol=1,
 ly<-rbind(c(1,2),c(3,4))
 grid.arrange(layout_matrix=ly,
              tgrob.mod,like.p,gt_est,gt_true,heights = c(60,60))
-
-grid.arrange(ncol = 1,
-             #top="Recruitment",
-             rec1, R.resid)
 
 grid.arrange(ncol = 1,
   #top="Recruitment",
@@ -1668,8 +1774,10 @@ sink()
 
 }
 
-
 make.plots()
+
+#} #end running the whole code
+
 
 #} #end loops if doing many runs
   


### PR DESCRIPTION
Further generalized code to handle any model name which is entered in the run set up. Code now recognizes selectivity configuration for fishery and survey (input, logistic, etc) and will only populate true and estimated parameter tables with parameters corresponding to set up (e.g. logistic only shows beta 1 and 2). Tidied up the tables so they are not overlapping. Adjusted font size. To work correctly, the OM .dat switch title needs to be select_switch_EM or select_switch_survey_EM. Might need to change that in whatever .dat is being used. I fixed it manually in the current OM .dat. 